### PR TITLE
Fix user ID propagation to data agent

### DIFF
--- a/expense_tracker/sub_agents/data_agent/tools/data_agent_tool.py
+++ b/expense_tracker/sub_agents/data_agent/tools/data_agent_tool.py
@@ -5,7 +5,6 @@ from typing import Dict, Any
 from .db_utils import get_expenses_for_user
 from collections import defaultdict
 from datetime import datetime
-from google.adk.agents.invocation_context import InvocationContext
 
 logger = logging.getLogger(__name__)
 
@@ -20,12 +19,9 @@ async def data_agent_tool(user_id: str, tool_context: ToolContext, months: int =
     Returns:
         A dictionary containing the aggregated spend history.
     """
-    # resolved_user_id = tool_context.state.get("user_id")
-    resolved_user_id = tool_context.user_state.get("user_id")
+    # Prefer the explicit user_id argument if provided
+    resolved_user_id = user_id or tool_context.user_state.get("user_id")
     logger.info("Logging resolved_user_id: %s", resolved_user_id)
-    
-    # implementing the below for TESTING purposes
-    # resolved_user_id = "streamlit-user-1"
 
     if not resolved_user_id:
         logger.error("Error: User ID not found in tool argument or ToolContext.")

--- a/ui/app.py
+++ b/ui/app.py
@@ -72,7 +72,7 @@ if uploaded:
     data_b64 = base64.b64encode(uploaded.read()).decode()
     payload = {
         "appName":   APP_NAME,
-        "user_id":   USER_ID,
+        "userId":    USER_ID,
         "sessionId": sid,
         "streaming": False,
         "newMessage": {


### PR DESCRIPTION
## Summary
- send `userId` field expected by ADK from the Streamlit UI
- rely on the passed `user_id` argument in `data_agent_tool`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877afc7c72c832799a1525fcc8744fb